### PR TITLE
add version to manifest for HA 2021.6 compatibility

### DIFF
--- a/custom_components/picnic/manifest.json
+++ b/custom_components/picnic/manifest.json
@@ -4,5 +4,6 @@
     "documentation": "https://github.com/MikeBrink/home-assistant-picnic",
     "issue_tracker": "https://github.com/MikeBrink/home-assistant-picnic/issues",
     "codeowners": ["@MikeBrink"],
+    "version": "v0.2.2",    
     "requirements": ["python-picnic-api==0.2.2"]
 }


### PR DESCRIPTION
2021.6 will require all components to have a version:
https://community.home-assistant.io/t/no-version-key-in-the-manifest-file-for-custom-integration-ha-2021-3-0/286487/5